### PR TITLE
Enable golangci-lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,17 @@ jobs:
       run: GO111MODULE=off go get golang.org/x/lint/golint
     - name: Compile
       run: make build
+    - name: Lint
+      run: make lint
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.38.0
+        skip-go-installation: true
+        skip-pkg-cache: true
+        skip-build-cache: true
     - name: Test
-      run: make test
+      run: make test-unit
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+---
+linters:
+  enable:
+  - gci
+  - gofmt
+  disable-all: false

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ image:
 	docker build . -t quay.io/kohlstechnology/blackbox-helloworld-responder:latest
 
 .PHONY: test
-test: fmt vet lint test-unit
+test: lint-all test-unit
 
 .PHONY: test-unit
 test-unit:
@@ -39,17 +39,16 @@ test-dirty: build
 test-release:
 	BRANCH=$(BRANCH) COMMIT=$(COMMIT) DATE=$(DATE) VERSION_PKG=$(VERSION_PKG) goreleaser --snapshot --skip-publish --rm-dist
 
-.PHONY: fmt
-fmt:
-	test -z "$(shell gofmt -l .)"
-
 .PHONY: lint
 lint:
 	LINT_INPUT="$(shell go list ./...)"; golint -set_exit_status $$LINT_INPUT
 
-.PHONY: vet
-vet:
-	VET_INPUT="$(shell go list ./...)"; go vet $$VET_INPUT
+.PHONY: golangci-lint
+golangci-lint:
+	golangci-lint run
+
+.PHONY: lint-all
+lint-all: lint golangci-lint
 
 .PHONY: tag
 tag:

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func httpHelloServer(port int) {
 		Handler:      mux,
 	}
 	mux.HandleFunc("/", httpHelloHandler)
-	httpsrv.ListenAndServe()
+	log.Fatal(httpsrv.ListenAndServe())
 }
 
 // httpHelloServer starts a simple HelloWorld TCP Server

--- a/main.go
+++ b/main.go
@@ -88,7 +88,10 @@ func tcpHelloServer(port int) {
 			log.Fatal(err)
 		}
 		log.Printf("TCP %s\n", connection.RemoteAddr())
-		connection.Write([]byte(`Hello World!`))
+		_, err = connection.Write([]byte(`Hello World!`))
+		if err != nil {
+			log.Println(err)
+		}
 		connection.Close()
 	}
 }


### PR DESCRIPTION
The golangci-lint tool replaces fmt and vet. At this point in time
golint is still run separately because golangci-lint seems to not be
able to enforce requiring package and function comments.

The golangci-lint also adds serveral other static code analysis tools by
default.

Part of #4 