### PR TITLE
Run Go Releaser Using Make

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -43,6 +43,13 @@ jobs:
         fail_ci_if_error: true
         files: ./coverage.txt
         verbose: true
+    - name: Install GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        install-only: true
+        version: v0.162.0
+    - name: Test GoReleaser
+      run: make test-release
   deploy:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: test
@@ -53,10 +60,6 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          echo "BRANCH=$(git symbolic-ref --short -q HEAD || echo HEAD)" >> $GITHUB_ENV                          # for goreleaser
-          echo "COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV                                                     # for goreleaser
-          echo "DATE=$(date -u +%Y%m%d-%H:%M:%S)" >> $GITHUB_ENV                                                 # for goreleaser
-          echo "VERSION_PKG=github.com/KohlsTechnology/blackbox-helloworld-responder/pkg/version" >> $GITHUB_ENV # for goreleaser
           DOCKER_IMAGE=quay.io/kohlstechnology/blackbox-helloworld-responder
           VERSION=${GITHUB_REF#refs/tags/}
           TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:latest"
@@ -75,10 +78,12 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.prep.outputs.tags }}
-      - name: Run GoReleaser
+      - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
-          args: release --rm-dist
+          install-only: true
+          version: v0.162.0
+      - name: Run GoReleaser
+        run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-dirty: build
 # Make sure goreleaser is working
 .PHONY: test-release
 test-release:
-	BRANCH=$(BRANCH) COMMIT=$(COMMIT) DATE=$(DATE) VERSION_PKG=$(VERSION_PKG) goreleaser --snapshot --skip-publish --rm-dist
+	BRANCH=$(BRANCH) COMMIT=$(COMMIT) DATE=$(DATE) VERSION_PKG=$(VERSION_PKG) goreleaser release --snapshot --skip-publish --rm-dist
 
 .PHONY: lint
 lint:
@@ -58,4 +58,4 @@ tag:
 # Requires GITHUB_TOKEN environment variable to be set
 .PHONY: release
 release:
-	BRANCH=$(BRANCH) COMMIT=$(COMMIT) DATE=$(DATE) VERSION_PKG=$(VERSION_PKG) goreleaser
+	BRANCH=$(BRANCH) COMMIT=$(COMMIT) DATE=$(DATE) VERSION_PKG=$(VERSION_PKG) goreleaser release --rm-dist


### PR DESCRIPTION
This ensures that the automated pipeline and local development always
match. Also does a test release for each PR.