### PR TITLE
Release v0.1.6

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.11, 1.16.2]
+        go-version: [1.15.11, 1.16.1]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.11 AS builder
+FROM golang:1.16.1 AS builder
 
 WORKDIR /go/src/github.com/KohlsTechnology/blackbox-helloworld-responder
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/KohlsTechnology/blackbox-helloworld-responder
 
-go 1.15
+go 1.16

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,7 +26,7 @@ var (
 	Branch    string
 	BuildDate string
 	GitSHA1   string
-	Version   = "v0.1.5"
+	Version   = "v0.1.6"
 )
 
 // Get returns the version string with some additional details


### PR DESCRIPTION
The PR contains two commits:
* 845d0524af1369aebc8b80b756f38bd94af5511e - bump to Go 1.16.1
* ef77eed80c25263eb01eadec50b8b14003f68034 - release v0.1.6

Still testing the release automation, so not bumping to the latest Go version yet.