### PR TITLE
chore(ci): checkout code before setting up go in test Action

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,12 +16,12 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v3
     - name: Compile
       run: make build
     - name: golangci-lint


### PR DESCRIPTION
## Description

Checkout code before setting up go in test Action.
This allows caching to work while using setup-go and cleans up the warning from the GitHub Action.

This also cleans up the following warning that was introduced when upgrading to [actions/setup-go@v4](https://github.com/actions/setup-go#v4) in #102 
> Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/blackbox-helloworld-responder/blackbox-helloworld-responder. Supported file pattern: go.sum

## Type of change

* Bug fix (non-breaking change which fixes an issue)